### PR TITLE
handle empty line in output

### DIFF
--- a/check_apache-auto.pl
+++ b/check_apache-auto.pl
@@ -167,6 +167,7 @@ sub apache_status($) {
     @recolte = split(/\n/,$htmlbrut);
     splice (@recolte, 0, $topnbr);
     splice (@recolte, -$endnbr);
+    @recolte = grep { $_ ne '' } @recolte;
 
     #Debugging
     # print "$req\n";


### PR DESCRIPTION
empty line in $htmlbrut can lead to empty array element in @recolte wich breaks mapping to %valtab